### PR TITLE
Moves handling of detached push/pops into dedicated class

### DIFF
--- a/MFBNavigation.xcodeproj/project.pbxproj
+++ b/MFBNavigation.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		E21864CA1DDCE27600531549 /* MFBModalNavigatorSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */; };
 		E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21864CB1DDCE2F800531549 /* Dummy.swift */; };
 		E291F4AD1E5C90D500704183 /* MFBAlertNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */; };
+		E2DEEA881E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */; };
+		E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */; };
+		E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */; };
 		E2FD4C101DDCE6E00039A531 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E21864C31DDCE10900531549 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2FD4C111DDCE6E00039A531 /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E21864C71DDCE25B00531549 /* OCMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2FD4C121DDCE6E00039A531 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E21864C41DDCE10900531549 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -76,6 +80,10 @@
 		E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBModalNavigatorSpec.m; sourceTree = "<group>"; };
 		E21864CB1DDCE2F800531549 /* Dummy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBAlertNavigation.h; sourceTree = "<group>"; };
+		E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFBPushPopNavigator+Test.h"; sourceTree = "<group>"; };
+		E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBNavigationChildrenReplacer.h; sourceTree = "<group>"; };
+		E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacer.m; sourceTree = "<group>"; };
+		E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacerSpec.m; sourceTree = "<group>"; };
 		E2FD4C131DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBPushPopNavigatorSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -126,15 +134,18 @@
 				E218649A1DDCD41700531549 /* Info.plist */,
 				E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */,
 				E21864B41DDCD6ED00531549 /* MFBAlertProxy.h */,
+				E21864B01DDCD56B00531549 /* MFBModalNavigation.h */,
 				E21864B61DDCD79E00531549 /* MFBModalNavigator.h */,
 				E21864B71DDCD79E00531549 /* MFBModalNavigator.m */,
-				E21864B01DDCD56B00531549 /* MFBModalNavigation.h */,
+				E21864991DDCD41700531549 /* MFBNavigation.h */,
+				E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */,
+				E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */,
+				E21864B11DDCD56B00531549 /* MFBPushPopNavigation.h */,
 				E21864B81DDCD79E00531549 /* MFBPushPopNavigator.h */,
 				E21864B91DDCD79E00531549 /* MFBPushPopNavigator.m */,
-				E21864B11DDCD56B00531549 /* MFBPushPopNavigation.h */,
-				E21864991DDCD41700531549 /* MFBNavigation.h */,
 				E21864BE1DDCD7D000531549 /* MFBSuspendibleUIQueue.h */,
 				E21864BF1DDCD7D000531549 /* MFBSuspendibleUIQueue.m */,
+				E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */,
 			);
 			path = MFBNavigation;
 			sourceTree = "<group>";
@@ -145,6 +156,7 @@
 				E21864CB1DDCE2F800531549 /* Dummy.swift */,
 				E21864A61DDCD41700531549 /* Info.plist */,
 				E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */,
+				E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */,
 				E2FD4C131DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m */,
 			);
 			path = MFBNavigationTests;
@@ -171,10 +183,12 @@
 				E21864A71DDCD41700531549 /* MFBNavigation.h in Headers */,
 				E21864BC1DDCD79E00531549 /* MFBPushPopNavigator.h in Headers */,
 				E21864B31DDCD56B00531549 /* MFBPushPopNavigation.h in Headers */,
+				E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */,
 				E21864B21DDCD56B00531549 /* MFBModalNavigation.h in Headers */,
 				E21864C01DDCD7D000531549 /* MFBSuspendibleUIQueue.h in Headers */,
 				E21864BA1DDCD79E00531549 /* MFBModalNavigator.h in Headers */,
 				E291F4AD1E5C90D500704183 /* MFBAlertNavigation.h in Headers */,
+				E2DEEA881E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -283,6 +297,7 @@
 				E21864C11DDCD7D000531549 /* MFBSuspendibleUIQueue.m in Sources */,
 				E21864BB1DDCD79E00531549 /* MFBModalNavigator.m in Sources */,
 				E21864BD1DDCD79E00531549 /* MFBPushPopNavigator.m in Sources */,
+				E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +306,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E21864CA1DDCE27600531549 /* MFBModalNavigatorSpec.m in Sources */,
+				E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */,
 				E2FD4C141DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m in Sources */,
 				E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */,
 			);

--- a/MFBNavigation/MFBNavigationChildrenReplacer.h
+++ b/MFBNavigation/MFBNavigationChildrenReplacer.h
@@ -2,12 +2,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSArray<UIViewController *> *_Nonnull(^MFBNavigationChildrenReplacerMapping)(NSArray<UIViewController *> *currentViewControllers);
-
 @interface MFBNavigationChildrenReplacer : NSObject
 
 - (void)replaceChildrenInNavigationController:(UINavigationController *)navigationController
-                                    byMapping:(MFBNavigationChildrenReplacerMapping)mapping
+                                 withChildren:(NSArray<UIViewController *> *)newChildren
                                    completion:(nullable dispatch_block_t)completion;
 
 @end

--- a/MFBNavigation/MFBNavigationChildrenReplacer.h
+++ b/MFBNavigation/MFBNavigationChildrenReplacer.h
@@ -1,0 +1,15 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSArray<UIViewController *> *_Nonnull(^MFBNavigationChildrenReplacerMapping)(NSArray<UIViewController *> *currentViewControllers);
+
+@interface MFBNavigationChildrenReplacer : NSObject
+
+- (void)replaceChildrenInNavigationController:(UINavigationController *)navigationController
+                                    byMapping:(MFBNavigationChildrenReplacerMapping)mapping
+                                   completion:(nullable dispatch_block_t)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MFBNavigation/MFBNavigationChildrenReplacer.m
+++ b/MFBNavigation/MFBNavigationChildrenReplacer.m
@@ -3,16 +3,14 @@
 @implementation MFBNavigationChildrenReplacer
 
 - (void)replaceChildrenInNavigationController:(UINavigationController *)navigationController
-                                    byMapping:(MFBNavigationChildrenReplacerMapping)mapping
+                                 withChildren:(NSArray<UIViewController *> *)newChildren
                                    completion:(nullable dispatch_block_t)completion
 {
-    NSCParameterAssert(mapping != nil);
     NSCParameterAssert(navigationController != nil);
-
-    __auto_type newViewControllers = mapping(navigationController.viewControllers);
+    NSCParameterAssert(newChildren != nil);
 
     [UIView performWithoutAnimation:^{
-        [navigationController setViewControllers:newViewControllers animated:NO];
+        [navigationController setViewControllers:newChildren animated:NO];
     }];
 
     if (completion) {

--- a/MFBNavigation/MFBNavigationChildrenReplacer.m
+++ b/MFBNavigation/MFBNavigationChildrenReplacer.m
@@ -1,0 +1,23 @@
+#import "MFBNavigationChildrenReplacer.h"
+
+@implementation MFBNavigationChildrenReplacer
+
+- (void)replaceChildrenInNavigationController:(UINavigationController *)navigationController
+                                    byMapping:(MFBNavigationChildrenReplacerMapping)mapping
+                                   completion:(nullable dispatch_block_t)completion
+{
+    NSCParameterAssert(mapping != nil);
+    NSCParameterAssert(navigationController != nil);
+
+    __auto_type newViewControllers = mapping(navigationController.viewControllers);
+
+    [UIView performWithoutAnimation:^{
+        [navigationController setViewControllers:newViewControllers animated:NO];
+    }];
+
+    if (completion) {
+        completion();
+    }
+}
+
+@end

--- a/MFBNavigation/MFBPushPopNavigator+Test.h
+++ b/MFBNavigation/MFBPushPopNavigator+Test.h
@@ -1,0 +1,9 @@
+#import "MFBPushPopNavigator.h"
+
+@class MFBNavigationChildrenReplacer;
+
+@interface MFBPushPopNavigator (Test)
+
+- (void)setNavigationChildrenReplacer:(MFBNavigationChildrenReplacer *)childrenReplacer;
+
+@end

--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -85,12 +85,8 @@
 
             [navigationController popToRootViewControllerAnimated:animated];
         } else {
-            __auto_type mapping = ^(NSArray<UIViewController *> *currentViewControllers) {
-                return @[ currentViewControllers[0] ];
-            };
-
             [_childrenReplacer replaceChildrenInNavigationController:navigationController
-                                                           byMapping:mapping
+                                                        withChildren:@[ navigationController.viewControllers[0] ]
                                                           completion:completion];
         }
     }];
@@ -113,13 +109,12 @@
             [_transitionQueue suspend];
             [navigationController pushViewController:viewController animated:animated];
         } else {
-            __auto_type mapping = ^(NSArray<UIViewController *> *currentViewControllers) {
-                NSMutableArray<UIViewController *> *newViewControllers = [currentViewControllers mutableCopy];
-                [newViewControllers addObject:viewController];
-                return newViewControllers;
-            };
+            NSMutableArray<UIViewController *> *newViewControllers = [navigationController.viewControllers mutableCopy];
+            [newViewControllers addObject:viewController];
 
-            [_childrenReplacer replaceChildrenInNavigationController:navigationController byMapping:mapping completion:completion];
+            [_childrenReplacer replaceChildrenInNavigationController:navigationController
+                                                        withChildren:newViewControllers
+                                                          completion:completion];
         }
     }];
 }
@@ -153,8 +148,11 @@
                 return [currentViewControllers subarrayWithRange:newRange];
             };
 
+            NSRange newRange = NSMakeRange(0, targetViewControllerIndex + 1);
+            __auto_type newViewControllers = [navigationController.viewControllers subarrayWithRange:newRange];
+
             [_childrenReplacer replaceChildrenInNavigationController:navigationController
-                                                           byMapping:mapping
+                                                        withChildren:newViewControllers
                                                           completion:nil];
         }
     }];
@@ -182,13 +180,12 @@
             [_transitionQueue suspend];
             [navigationController popViewControllerAnimated:animated];
         } else {
-            __auto_type mapping = ^(NSArray<UIViewController *> *currentViewControllers) {
-                NSMutableArray<UIViewController *> *newViewControllers = [currentViewControllers mutableCopy];
-                [newViewControllers removeObjectAtIndex:newViewControllers.count - 1];
-                return newViewControllers;
-            };
+            NSMutableArray<UIViewController *> *newViewControllers = [navigationController.viewControllers mutableCopy];
+            [newViewControllers removeObjectAtIndex:newViewControllers.count - 1];
 
-            [_childrenReplacer replaceChildrenInNavigationController:navigationController byMapping:mapping completion:completion];
+            [_childrenReplacer replaceChildrenInNavigationController:navigationController
+                                                        withChildren:newViewControllers
+                                                          completion:completion];
         }
     }];
 }

--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -143,11 +143,6 @@
             [_transitionQueue suspend];
             [navigationController popToViewController:viewController animated:animated];
         } else {
-            __auto_type mapping = ^(NSArray<UIViewController *> *currentViewControllers) {
-                NSRange newRange = NSMakeRange(0, targetViewControllerIndex + 1);
-                return [currentViewControllers subarrayWithRange:newRange];
-            };
-
             NSRange newRange = NSMakeRange(0, targetViewControllerIndex + 1);
             __auto_type newViewControllers = [navigationController.viewControllers subarrayWithRange:newRange];
 

--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -169,7 +169,7 @@
             return;
         }
 
-        if (navigationController.viewControllers.count <= 1) {
+        if (navigationController.viewControllers.count < 2) {
             if (completion) {
                 completion();
             }

--- a/MFBNavigationTests/MFBNavigationChildrenReplacerSpec.m
+++ b/MFBNavigationTests/MFBNavigationChildrenReplacerSpec.m
@@ -19,15 +19,12 @@ beforeEach(^{
 });
 
 it(@"replaces view controllers in animationless manner after applying transformation to current ones and calls completion thereafter", ^{
-    id currentViewControllersStub = [NSObject new];
-    id mappedViewControllersStub = [NSObject new];
+    id newViewControllersStub = [NSObject new];
 
     __block NSInteger completionCalledTimes = 0;
 
-    OCMExpect([navigationControllerMock viewControllers]).andReturn(currentViewControllersStub);
-
     OCMExpect([viewClassMock performWithoutAnimation:[OCMArg checkWithBlock:^(dispatch_block_t block) {
-        OCMExpect([navigationControllerMock setViewControllers:mappedViewControllersStub animated:NO])
+        OCMExpect([navigationControllerMock setViewControllers:newViewControllersStub animated:NO])
             .andDo(^(NSInvocation *_) {
                 XCTAssertEqual(completionCalledTimes, 0);
             });
@@ -37,14 +34,8 @@ it(@"replaces view controllers in animationless manner after applying transforma
         return YES;
     }]]);
 
-    __auto_type mapper = ^(NSArray<UIViewController *> *currentViewControllers) {
-        XCTAssertEqual(currentViewControllers, currentViewControllersStub);
-
-        return mappedViewControllersStub;
-    };
-
     [replacer replaceChildrenInNavigationController:navigationControllerMock
-                                          byMapping:mapper
+                                       withChildren:newViewControllersStub
                                          completion:^{
                                              completionCalledTimes++;
                                          }];

--- a/MFBNavigationTests/MFBNavigationChildrenReplacerSpec.m
+++ b/MFBNavigationTests/MFBNavigationChildrenReplacerSpec.m
@@ -1,0 +1,58 @@
+#import <OCMock/OCMock.h>
+#import <Quick/Quick.h>
+#import <XCTest/XCTest.h>
+
+#import "MFBNavigationChildrenReplacer.h"
+
+QuickSpecBegin(NavigationChildrenReplacer)
+
+__block id navigationControllerMock;
+__block id viewClassMock;
+
+__block MFBNavigationChildrenReplacer *replacer;
+
+beforeEach(^{
+    viewClassMock = OCMStrictClassMock(UIView.class);
+    navigationControllerMock = OCMStrictClassMock(UINavigationController.class);
+
+    replacer = [MFBNavigationChildrenReplacer new];
+});
+
+it(@"replaces view controllers in animationless manner after applying transformation to current ones and calls completion thereafter", ^{
+    id currentViewControllersStub = [NSObject new];
+    id mappedViewControllersStub = [NSObject new];
+
+    __block NSInteger completionCalledTimes = 0;
+
+    OCMExpect([navigationControllerMock viewControllers]).andReturn(currentViewControllersStub);
+
+    OCMExpect([viewClassMock performWithoutAnimation:[OCMArg checkWithBlock:^(dispatch_block_t block) {
+        OCMExpect([navigationControllerMock setViewControllers:mappedViewControllersStub animated:NO])
+            .andDo(^(NSInvocation *_) {
+                XCTAssertEqual(completionCalledTimes, 0);
+            });
+
+        block();
+
+        return YES;
+    }]]);
+
+    __auto_type mapper = ^(NSArray<UIViewController *> *currentViewControllers) {
+        XCTAssertEqual(currentViewControllers, currentViewControllersStub);
+
+        return mappedViewControllersStub;
+    };
+
+    [replacer replaceChildrenInNavigationController:navigationControllerMock
+                                          byMapping:mapper
+                                         completion:^{
+                                             completionCalledTimes++;
+                                         }];
+
+    OCMVerifyAll(navigationControllerMock);
+    OCMVerifyAll(viewClassMock);
+
+    XCTAssertEqual(completionCalledTimes, 1);
+});
+
+QuickSpecEnd

--- a/MFBNavigationTests/MFBPushPopNavigatorSpec.m
+++ b/MFBNavigationTests/MFBPushPopNavigatorSpec.m
@@ -180,16 +180,8 @@ describe(@"navigation", ^{
 
                 OCMStub([navigationControllerMock viewControllers]).andReturn(viewControllersStub);
 
-                id replacerMappingMatcher = [OCMArg checkWithBlock:^(MFBNavigationChildrenReplacerMapping mapping) {
-                    __auto_type mappedViewControllers = mapping(viewControllersStub);
-
-                    XCTAssertEqualObjects(mappedViewControllers, expectedViewControllers);
-
-                    return YES;
-                }];
-
                 OCMExpect([childrenReplacerMock replaceChildrenInNavigationController:navigationControllerMock
-                                                                            byMapping:replacerMappingMatcher
+                                                                         withChildren:expectedViewControllers
                                                                            completion:completion]);
 
                 [pushPopNavigator pushViewController:pushedViewControllerStub animated:YES completion:completion];
@@ -311,16 +303,8 @@ describe(@"navigation", ^{
 
                 OCMStub([navigationControllerMock viewControllers]).andReturn(viewControllersStub);
 
-                id replacerMappingMatcher = [OCMArg checkWithBlock:^(MFBNavigationChildrenReplacerMapping mapper) {
-                    __auto_type mappedViewControllers = mapper(viewControllersStub);
-
-                    XCTAssertEqualObjects(mappedViewControllers, expectedViewControllers);
-
-                    return YES;
-                }];
-
                 OCMExpect([childrenReplacerMock replaceChildrenInNavigationController:navigationControllerMock
-                                                                            byMapping:replacerMappingMatcher
+                                                                         withChildren:expectedViewControllers
                                                                            completion:completion]);
 
                 [pushPopNavigator popViewControllerAnimated:YES completion:completion];
@@ -420,16 +404,8 @@ describe(@"navigation", ^{
                 OCMStub([navigationControllerMock viewControllers]).andReturn(viewControllersStub);
                 OCMStub([navigationControllerMock topViewController]).andReturn(viewControllersStub.lastObject);
 
-                id replacerMappingMatcher = [OCMArg checkWithBlock:^(MFBNavigationChildrenReplacerMapping mapper) {
-                    __auto_type mappedViewControllers = mapper(viewControllersStub);
-
-                    XCTAssertEqualObjects(mappedViewControllers, expectedViewControllers);
-
-                    return YES;
-                }];
-
                 OCMExpect([childrenReplacerMock replaceChildrenInNavigationController:navigationControllerMock
-                                                                            byMapping:replacerMappingMatcher
+                                                                         withChildren:expectedViewControllers
                                                                            completion:nil]);
 
                 [pushPopNavigator popToViewController:targetViewControllerStub animated:YES];
@@ -571,16 +547,8 @@ describe(@"navigation", ^{
 
                 OCMStub([navigationControllerMock viewControllers]).andReturn(viewControllersStub);
 
-                id replacerMappingMatcher = [OCMArg checkWithBlock:^(MFBNavigationChildrenReplacerMapping mapper) {
-                    __auto_type mappedViewControllers = mapper(viewControllersStub);
-
-                    XCTAssertEqualObjects(mappedViewControllers, expectedViewControllers);
-
-                    return YES;
-                }];
-
                 OCMExpect([childrenReplacerMock replaceChildrenInNavigationController:navigationControllerMock
-                                                                            byMapping:replacerMappingMatcher
+                                                                         withChildren:expectedViewControllers
                                                                            completion:completion]);
 
                 [pushPopNavigator popToRootAnimated:YES completion:completion];


### PR DESCRIPTION
Objects of this class are responsible for updating navigation stack & disabling UIView animations during a detached transition.

Since the handling of detached transitions is now unified across all transitions, this change fixes #13.

This PR uses `+[UIView performWithoutAnimation:]` call to rule out implicit animations during detached transitions. Previously a pair of `+[UIView setAnimationsEnabled:]` calls was used, but this was unreliable (imagine some UIKit internals changing this flag during transition) and harder to test.