### PR TITLE
Adds unwind support to push/pop navigation

### DIFF
--- a/MFBNavigation.podspec
+++ b/MFBNavigation.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/flix-tech/MFBNavigation.git", :tag => "#{s.version}" }
 
   s.source_files  = "Classes", "MFBNavigation/**/*.{h,m}"
-  s.public_header_files = 'MFBNavigation/**/{MFBAlertNavigation,MFBAlertProxy,MFBModalNavigation,MFBModalNavigator,MFBPushPopNavigation,MFBPushPopNavigator,MFBSuspendibleUIQueue}.h'
+  s.public_header_files = 'MFBNavigation/**/{MFBAlertNavigation,MFBAlertProxy,MFBModalNavigation,MFBModalNavigator,MFBPushPopNavigation,MFBPushPopNavigator,MFBSuspendibleUIQueue,MFBUnwindToken}.h'
 
   s.frameworks = "UIKit"
 

--- a/MFBNavigation.xcodeproj/project.pbxproj
+++ b/MFBNavigation.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		E2D7F9D81F1E568E00166297 /* MFBUnwindToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2D7F9DB1F1E56CD00166297 /* MFBUIKitUnwindToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */; };
 		E2D7F9DC1F1E56CD00166297 /* MFBUIKitUnwindToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */; };
-		E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */; };
+		E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindTokenSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindTokenSpec.m */; };
 		E2DEEA881E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */; };
 		E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */; };
 		E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */; };
@@ -88,7 +88,7 @@
 		E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUnwindToken.h; sourceTree = "<group>"; };
 		E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUIKitUnwindToken.h; sourceTree = "<group>"; };
 		E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindToken.m; sourceTree = "<group>"; };
-		E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindToken.m; sourceTree = "<group>"; };
+		E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindTokenSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindTokenSpec.m; sourceTree = "<group>"; };
 		E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBNavigationChildrenReplacer.h; sourceTree = "<group>"; };
 		E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacer.m; sourceTree = "<group>"; };
 		E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacerSpec.m; sourceTree = "<group>"; };
@@ -169,7 +169,7 @@
 				E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */,
 				E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */,
 				E2FD4C131DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m */,
-				E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */,
+				E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindTokenSpec.m */,
 			);
 			path = MFBNavigationTests;
 			sourceTree = "<group>";
@@ -321,7 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E21864CA1DDCE27600531549 /* MFBModalNavigatorSpec.m in Sources */,
-				E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindToken.m in Sources */,
+				E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindTokenSpec.m in Sources */,
 				E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */,
 				E2FD4C141DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m in Sources */,
 				E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */,

--- a/MFBNavigation.xcodeproj/project.pbxproj
+++ b/MFBNavigation.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		E21864C81DDCE25B00531549 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21864C71DDCE25B00531549 /* OCMock.framework */; };
 		E21864CA1DDCE27600531549 /* MFBModalNavigatorSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */; };
 		E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21864CB1DDCE2F800531549 /* Dummy.swift */; };
+		E21961BB1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = E21961B91F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.h */; };
+		E21961BC1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E21961BA1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.m */; };
 		E291F4AD1E5C90D500704183 /* MFBAlertNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */; };
 		E2D7F9D81F1E568E00166297 /* MFBUnwindToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -83,6 +85,8 @@
 		E21864C71DDCE25B00531549 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
 		E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBModalNavigatorSpec.m; sourceTree = "<group>"; };
 		E21864CB1DDCE2F800531549 /* Dummy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
+		E21961B91F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUIKitUnwindTokenFactory.h; sourceTree = "<group>"; };
+		E21961BA1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindTokenFactory.m; sourceTree = "<group>"; };
 		E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBAlertNavigation.h; sourceTree = "<group>"; };
 		E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFBPushPopNavigator+Test.h"; sourceTree = "<group>"; };
 		E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUnwindToken.h; sourceTree = "<group>"; };
@@ -156,6 +160,8 @@
 				E21864BF1DDCD7D000531549 /* MFBSuspendibleUIQueue.m */,
 				E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */,
 				E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */,
+				E21961B91F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.h */,
+				E21961BA1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.m */,
 				E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */,
 			);
 			path = MFBNavigation;
@@ -196,6 +202,7 @@
 				E21864BC1DDCD79E00531549 /* MFBPushPopNavigator.h in Headers */,
 				E21864B31DDCD56B00531549 /* MFBPushPopNavigation.h in Headers */,
 				E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */,
+				E21961BB1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.h in Headers */,
 				E21864B21DDCD56B00531549 /* MFBModalNavigation.h in Headers */,
 				E2D7F9D81F1E568E00166297 /* MFBUnwindToken.h in Headers */,
 				E2D7F9DB1F1E56CD00166297 /* MFBUIKitUnwindToken.h in Headers */,
@@ -313,6 +320,7 @@
 				E21864BD1DDCD79E00531549 /* MFBPushPopNavigator.m in Sources */,
 				E2D7F9DC1F1E56CD00166297 /* MFBUIKitUnwindToken.m in Sources */,
 				E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */,
+				E21961BC1F1F42110055E2C9 /* MFBUIKitUnwindTokenFactory.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MFBNavigation.xcodeproj/project.pbxproj
+++ b/MFBNavigation.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21864CB1DDCE2F800531549 /* Dummy.swift */; };
 		E291F4AD1E5C90D500704183 /* MFBAlertNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */ = {isa = PBXBuildFile; fileRef = E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */; };
+		E2D7F9D81F1E568E00166297 /* MFBUnwindToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2D7F9DB1F1E56CD00166297 /* MFBUIKitUnwindToken.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */; };
+		E2D7F9DC1F1E56CD00166297 /* MFBUIKitUnwindToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */; };
+		E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindToken.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */; };
 		E2DEEA881E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */; };
 		E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */; };
 		E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */; };
@@ -81,6 +85,10 @@
 		E21864CB1DDCE2F800531549 /* Dummy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		E291F4AC1E5C90D500704183 /* MFBAlertNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBAlertNavigation.h; sourceTree = "<group>"; };
 		E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFBPushPopNavigator+Test.h"; sourceTree = "<group>"; };
+		E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUnwindToken.h; sourceTree = "<group>"; };
+		E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBUIKitUnwindToken.h; sourceTree = "<group>"; };
+		E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindToken.m; sourceTree = "<group>"; };
+		E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBUIKitUnwindToken.m; sourceTree = "<group>"; };
 		E2DEEA861E66D23300A1DF4D /* MFBNavigationChildrenReplacer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFBNavigationChildrenReplacer.h; sourceTree = "<group>"; };
 		E2DEEA871E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacer.m; sourceTree = "<group>"; };
 		E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFBNavigationChildrenReplacerSpec.m; sourceTree = "<group>"; };
@@ -143,9 +151,12 @@
 				E21864B11DDCD56B00531549 /* MFBPushPopNavigation.h */,
 				E21864B81DDCD79E00531549 /* MFBPushPopNavigator.h */,
 				E21864B91DDCD79E00531549 /* MFBPushPopNavigator.m */,
+				E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */,
 				E21864BE1DDCD7D000531549 /* MFBSuspendibleUIQueue.h */,
 				E21864BF1DDCD7D000531549 /* MFBSuspendibleUIQueue.m */,
-				E2AAF35F1E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h */,
+				E2D7F9D91F1E56CD00166297 /* MFBUIKitUnwindToken.h */,
+				E2D7F9DA1F1E56CD00166297 /* MFBUIKitUnwindToken.m */,
+				E2D7F9D71F1E568E00166297 /* MFBUnwindToken.h */,
 			);
 			path = MFBNavigation;
 			sourceTree = "<group>";
@@ -158,6 +169,7 @@
 				E21864C91DDCE27600531549 /* MFBModalNavigatorSpec.m */,
 				E2DEEA8A1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m */,
 				E2FD4C131DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m */,
+				E2D7F9DD1F1E59FC00166297 /* MFBUIKitUnwindToken.m */,
 			);
 			path = MFBNavigationTests;
 			sourceTree = "<group>";
@@ -185,6 +197,8 @@
 				E21864B31DDCD56B00531549 /* MFBPushPopNavigation.h in Headers */,
 				E2AAF3611E66E2A0009F58A5 /* MFBPushPopNavigator+Test.h in Headers */,
 				E21864B21DDCD56B00531549 /* MFBModalNavigation.h in Headers */,
+				E2D7F9D81F1E568E00166297 /* MFBUnwindToken.h in Headers */,
+				E2D7F9DB1F1E56CD00166297 /* MFBUIKitUnwindToken.h in Headers */,
 				E21864C01DDCD7D000531549 /* MFBSuspendibleUIQueue.h in Headers */,
 				E21864BA1DDCD79E00531549 /* MFBModalNavigator.h in Headers */,
 				E291F4AD1E5C90D500704183 /* MFBAlertNavigation.h in Headers */,
@@ -297,6 +311,7 @@
 				E21864C11DDCD7D000531549 /* MFBSuspendibleUIQueue.m in Sources */,
 				E21864BB1DDCD79E00531549 /* MFBModalNavigator.m in Sources */,
 				E21864BD1DDCD79E00531549 /* MFBPushPopNavigator.m in Sources */,
+				E2D7F9DC1F1E56CD00166297 /* MFBUIKitUnwindToken.m in Sources */,
 				E2DEEA891E66D23300A1DF4D /* MFBNavigationChildrenReplacer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -306,6 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E21864CA1DDCE27600531549 /* MFBModalNavigatorSpec.m in Sources */,
+				E2D7F9DE1F1E59FC00166297 /* MFBUIKitUnwindToken.m in Sources */,
 				E2DEEA8B1E66D27B00A1DF4D /* MFBNavigationChildrenReplacerSpec.m in Sources */,
 				E2FD4C141DDF3D1B0039A531 /* MFBPushPopNavigatorSpec.m in Sources */,
 				E21864CC1DDCE2F800531549 /* Dummy.swift in Sources */,

--- a/MFBNavigation/MFBNavigation.h
+++ b/MFBNavigation/MFBNavigation.h
@@ -13,3 +13,4 @@ FOUNDATION_EXPORT const unsigned char MFBNavigationVersionString[];
 #import <MFBNavigation/MFBModalNavigator.h>
 #import <MFBNavigation/MFBPushPopNavigator.h>
 #import <MFBNavigation/MFBSuspendibleUIQueue.h>
+#import <MFBNavigation/MFBUnwindToken.h>

--- a/MFBNavigation/MFBPushPopNavigation.h
+++ b/MFBNavigation/MFBPushPopNavigation.h
@@ -1,14 +1,15 @@
 #import <UIKit/UIKit.h>
 
 #import "MFBModalNavigation.h"
+#import "MFBUnwindToken.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MFBPushPopNavigation <MFBModalNavigation>
 
-- (void)pushViewController:(UIViewController *)viewController
-                  animated:(BOOL)animated
-                completion:(nullable dispatch_block_t)completion;
+- (id<MFBUnwindToken>)pushViewController:(UIViewController *)viewController
+                                animated:(BOOL)animated
+                              completion:(nullable dispatch_block_t)completion;
 
 - (void)popViewControllerAnimated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 - (void)popToRootAnimated:(BOOL)animated completion:(nullable dispatch_block_t)completion;

--- a/MFBNavigation/MFBPushPopNavigation.h
+++ b/MFBNavigation/MFBPushPopNavigation.h
@@ -7,13 +7,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MFBPushPopNavigation <MFBModalNavigation>
 
-- (id<MFBUnwindToken>)pushViewController:(UIViewController *)viewController
-                                animated:(BOOL)animated
-                              completion:(nullable dispatch_block_t)completion;
+- (void)pushViewController:(UIViewController *)viewController
+                  animated:(BOOL)animated
+                completion:(nullable dispatch_block_t)completion;
 
 - (void)popViewControllerAnimated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 - (void)popToRootAnimated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 - (void)popToViewController:(UIViewController *)viewController animated:(BOOL)animated;
+
+- (id<MFBUnwindToken>)currentUnwindToken;
 
 @end
 

--- a/MFBNavigation/MFBPushPopNavigator+Test.h
+++ b/MFBNavigation/MFBPushPopNavigator+Test.h
@@ -1,9 +1,11 @@
 #import "MFBPushPopNavigator.h"
 
-@class MFBNavigationChildrenReplacer;
+#import "MFBNavigationChildrenReplacer.h"
+#import "MFBUIKitUnwindTokenFactory.h"
 
 @interface MFBPushPopNavigator (Test)
 
 - (void)setNavigationChildrenReplacer:(MFBNavigationChildrenReplacer *)childrenReplacer;
+- (void)setUnwindTokenFactory:(MFBUIKitUnwindTokenFactory *)unwindTokenFactory;
 
 @end

--- a/MFBNavigation/MFBPushPopNavigator+Test.h
+++ b/MFBNavigation/MFBPushPopNavigator+Test.h
@@ -3,9 +3,13 @@
 #import "MFBNavigationChildrenReplacer.h"
 #import "MFBUIKitUnwindTokenFactory.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MFBPushPopNavigator (Test)
 
 - (void)setNavigationChildrenReplacer:(MFBNavigationChildrenReplacer *)childrenReplacer;
 - (void)setUnwindTokenFactory:(MFBUIKitUnwindTokenFactory *)unwindTokenFactory;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -93,25 +93,17 @@
     }];
 }
 
-- (id<MFBUnwindToken>)pushViewController:(UIViewController *)viewController
-                                animated:(BOOL)animated
-                              completion:(nullable dispatch_block_t)completion
+- (void)pushViewController:(UIViewController *)viewController
+                  animated:(BOOL)animated
+                completion:(dispatch_block_t)completion
 {
     NSCParameterAssert(viewController != nil);
-
-    __auto_type token = [_unwindTokenFactory unwindTokenWithDelegate:self];
 
     [_transitionQueue enqueueBlock:^{
         __auto_type navigationController = _navigationController;
 
         if (!navigationController) {
             return;
-        }
-
-        __auto_type unwindTarget = navigationController.topViewController;
-
-        if (unwindTarget) {
-            [token setUnwindTarget:unwindTarget];
         }
 
         if (navigationController.view.window) {
@@ -128,8 +120,6 @@
                                                           completion:completion];
         }
     }];
-
-    return token;
 }
 
 - (void)popToViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -211,6 +201,21 @@
 - (void)dismissModalViewControllerAnimated:(BOOL)animated completion:(dispatch_block_t)completion
 {
     [_modalNavigator dismissModalViewControllerAnimated:animated completion:completion];
+}
+
+- (id<MFBUnwindToken>)currentUnwindToken
+{
+    __auto_type token = [_unwindTokenFactory unwindTokenWithDelegate:self];
+
+    [_transitionQueue enqueueBlock:^{
+        __auto_type unwindTarget = _navigationController.topViewController;
+
+        if (unwindTarget) {
+            [token setUnwindTarget:unwindTarget];
+        }
+    }];
+
+    return token;
 }
 
 #pragma mark - Test API

--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -1,11 +1,10 @@
 #import "MFBModalNavigator.h"
-#import "MFBNavigationChildrenReplacer.h"
 #import "MFBPushPopNavigator.h"
 #import "MFBPushPopNavigator+Test.h"
 #import "MFBSuspendibleUIQueue.h"
 
 
-@interface MFBPushPopNavigator () <UINavigationControllerDelegate>
+@interface MFBPushPopNavigator () <UINavigationControllerDelegate, MFBUIKitUnwindDelegate>
 
 @end
 
@@ -16,6 +15,7 @@
     MFBNavigationChildrenReplacer *_childrenReplacer;
     dispatch_block_t _transitionCompletion;
     MFBSuspendibleUIQueue *_transitionQueue;
+    MFBUIKitUnwindTokenFactory *_unwindTokenFactory;
 }
 
 - (instancetype)init
@@ -45,6 +45,7 @@
                                                                             viewController:navigationController];
 
     _childrenReplacer = [MFBNavigationChildrenReplacer new];
+    _unwindTokenFactory = [MFBUIKitUnwindTokenFactory new];
 
     return self;
 }
@@ -92,15 +93,25 @@
     }];
 }
 
-- (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(dispatch_block_t)completion
+- (id<MFBUnwindToken>)pushViewController:(UIViewController *)viewController
+                                animated:(BOOL)animated
+                              completion:(nullable dispatch_block_t)completion
 {
     NSCParameterAssert(viewController != nil);
+
+    __auto_type token = [_unwindTokenFactory unwindTokenWithDelegate:self];
 
     [_transitionQueue enqueueBlock:^{
         __auto_type navigationController = _navigationController;
 
         if (!navigationController) {
             return;
+        }
+
+        __auto_type unwindTarget = navigationController.topViewController;
+
+        if (unwindTarget) {
+            [token setUnwindTarget:unwindTarget];
         }
 
         if (navigationController.view.window) {
@@ -117,6 +128,8 @@
                                                           completion:completion];
         }
     }];
+
+    return token;
 }
 
 - (void)popToViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -209,6 +222,13 @@
     _childrenReplacer = childrenReplacer;
 }
 
+- (void)setUnwindTokenFactory:(MFBUIKitUnwindTokenFactory *)unwindTokenFactory
+{
+    NSCParameterAssert(unwindTokenFactory != nil);
+
+    _unwindTokenFactory = unwindTokenFactory;
+}
+
 #pragma mark - Navigation controller delegate
 
 - (void)navigationController:(UINavigationController *)navigationController
@@ -260,6 +280,15 @@
     if ([delegate respondsToSelector:_cmd]) {
         [delegate navigationController:navigationController didShowViewController:viewController animated:animated];
     }
+}
+
+#pragma mark - UIKit Unwind Delegate
+
+- (void)unwindToTarget:(UIViewController *)unwindTarget
+{
+    NSCParameterAssert(unwindTarget != nil);
+
+    [self popToViewController:unwindTarget animated:YES];
 }
 
 @end

--- a/MFBNavigation/MFBUIKitUnwindToken.h
+++ b/MFBNavigation/MFBUIKitUnwindToken.h
@@ -1,0 +1,21 @@
+#import <UIKit/UIKit.h>
+
+#import "MFBUnwindToken.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MFBUIKitUnwindDelegate
+
+- (void)unwindToTarget:(UIViewController *)unwindTarget;
+
+@end
+
+@interface MFBUIKitUnwindToken : NSObject <MFBUnwindToken>
+
+- (void)setUnwindTarget:(UIViewController *)unwindTarget;
+
+@property (nonatomic, nullable, weak) id<MFBUIKitUnwindDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MFBNavigation/MFBUIKitUnwindToken.m
+++ b/MFBNavigation/MFBUIKitUnwindToken.m
@@ -56,13 +56,8 @@ typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
             break;
         }
         case NavigationUnwindTokenStateTriggered:
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"Unwind has already been triggered"
-                                         userInfo:nil];
         case NavigationUnwindTokenStateUnwound:
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"Unwind has already happened"
-                                         userInfo:nil];
+            break;
     }
 }
 

--- a/MFBNavigation/MFBUIKitUnwindToken.m
+++ b/MFBNavigation/MFBUIKitUnwindToken.m
@@ -1,0 +1,24 @@
+#import "MFBUIKitUnwindToken.h"
+
+typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
+    NavigationUnwindTokenStateIdle = 0,
+    NavigationUnwindTokenStateReady,
+    NavigationUnwindTokenStateTriggered,
+    NavigationUnwindTokenStateUnwound,
+};
+
+@implementation MFBUIKitUnwindToken
+
+#pragma mark - API
+
+- (void)setUnwindTarget:(UIViewController *)unwindTarget
+{
+    NSCParameterAssert(unwindTarget != nil);
+}
+
+- (void)unwind
+{
+
+}
+
+@end

--- a/MFBNavigation/MFBUIKitUnwindToken.m
+++ b/MFBNavigation/MFBUIKitUnwindToken.m
@@ -19,15 +19,24 @@ typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
 {
     NSCParameterAssert(unwindTarget != nil);
 
-    NSCAssert(_state != NavigationUnwindTokenStateReady, @"Unwind target has already been set");
-    NSCAssert(_state != NavigationUnwindTokenStateUnwound, @"Unwind has already happened");
+    switch (_state) {
+        case NavigationUnwindTokenStateIdle:
+            _unwindTarget = unwindTarget;
+            _state = NavigationUnwindTokenStateReady;
+            break;
 
-    if (_state == NavigationUnwindTokenStateTriggered) {
-        [_delegate unwindToTarget:unwindTarget];
-        _state = NavigationUnwindTokenStateUnwound;
-    } else {
-        _unwindTarget = unwindTarget;
-        _state = NavigationUnwindTokenStateReady;
+        case NavigationUnwindTokenStateTriggered:
+            [_delegate unwindToTarget:unwindTarget];
+            _state = NavigationUnwindTokenStateUnwound;
+            break;
+        case NavigationUnwindTokenStateReady:
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                           reason:@"Unwind target has already been set"
+                                         userInfo:nil];
+        case NavigationUnwindTokenStateUnwound:
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                           reason:@"Unwind has already happened"
+                                         userInfo:nil];
     }
 }
 
@@ -36,7 +45,7 @@ typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
     switch (_state) {
         case NavigationUnwindTokenStateIdle:
             _state = NavigationUnwindTokenStateTriggered;
-            return;
+            break;
 
         case NavigationUnwindTokenStateReady: {
             __auto_type unwindTarget = _unwindTarget;
@@ -44,7 +53,7 @@ typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
                 [_delegate unwindToTarget:unwindTarget];
             }
             _state = NavigationUnwindTokenStateUnwound;
-            return;
+            break;
         }
         case NavigationUnwindTokenStateTriggered:
             @throw [NSException exceptionWithName:NSInternalInconsistencyException

--- a/MFBNavigation/MFBUIKitUnwindToken.m
+++ b/MFBNavigation/MFBUIKitUnwindToken.m
@@ -7,18 +7,54 @@ typedef NS_ENUM(NSInteger, NavigationUnwindTokenState) {
     NavigationUnwindTokenStateUnwound,
 };
 
-@implementation MFBUIKitUnwindToken
+@implementation MFBUIKitUnwindToken {
+    NavigationUnwindTokenState _state;
+
+    __weak UIViewController *_unwindTarget;
+}
 
 #pragma mark - API
 
 - (void)setUnwindTarget:(UIViewController *)unwindTarget
 {
     NSCParameterAssert(unwindTarget != nil);
+
+    NSCAssert(_state != NavigationUnwindTokenStateReady, @"Unwind target has already been set");
+    NSCAssert(_state != NavigationUnwindTokenStateUnwound, @"Unwind has already happened");
+
+    if (_state == NavigationUnwindTokenStateTriggered) {
+        [_delegate unwindToTarget:unwindTarget];
+        _state = NavigationUnwindTokenStateUnwound;
+    } else {
+        _unwindTarget = unwindTarget;
+        _state = NavigationUnwindTokenStateReady;
+    }
 }
 
 - (void)unwind
 {
+    switch (_state) {
+        case NavigationUnwindTokenStateIdle:
+            _state = NavigationUnwindTokenStateTriggered;
+            return;
 
+        case NavigationUnwindTokenStateReady: {
+            __auto_type unwindTarget = _unwindTarget;
+            if (unwindTarget) {
+                [_delegate unwindToTarget:unwindTarget];
+            }
+            _state = NavigationUnwindTokenStateUnwound;
+            return;
+        }
+        case NavigationUnwindTokenStateTriggered:
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                           reason:@"Unwind has already been triggered"
+                                         userInfo:nil];
+        case NavigationUnwindTokenStateUnwound:
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                           reason:@"Unwind has already happened"
+                                         userInfo:nil];
+    }
 }
 
 @end

--- a/MFBNavigation/MFBUIKitUnwindTokenFactory.h
+++ b/MFBNavigation/MFBUIKitUnwindTokenFactory.h
@@ -1,0 +1,21 @@
+//
+//  MFBUIKitUnwindTokenFactory.h
+//  MFBNavigation
+//
+//  Created by Nikolay Kasyanov on 19.07.17.
+//  Copyright © 2017 FlixBus GmbH. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "MFBUIKitUnwindToken.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MFBUIKitUnwindTokenFactory : NSObject
+
+- (MFBUIKitUnwindToken *)unwindTokenWithDelegate:(id<MFBUIKitUnwindDelegate>)delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MFBNavigation/MFBUIKitUnwindTokenFactory.m
+++ b/MFBNavigation/MFBUIKitUnwindTokenFactory.m
@@ -1,0 +1,22 @@
+//
+//  MFBUIKitUnwindTokenFactory.m
+//  MFBNavigation
+//
+//  Created by Nikolay Kasyanov on 19.07.17.
+//  Copyright © 2017 FlixBus GmbH. All rights reserved.
+//
+
+#import "MFBUIKitUnwindTokenFactory.h"
+
+@implementation MFBUIKitUnwindTokenFactory
+
+- (MFBUIKitUnwindToken *)unwindTokenWithDelegate:(id<MFBUIKitUnwindDelegate>)delegate
+{
+    NSCParameterAssert(delegate != nil);
+
+    __auto_type token = [MFBUIKitUnwindToken new];
+    token.delegate = delegate;
+    return token;
+}
+
+@end

--- a/MFBNavigation/MFBUnwindToken.h
+++ b/MFBNavigation/MFBUnwindToken.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MFBUnwindToken
+
+- (void)unwind;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MFBNavigationTests/MFBPushPopNavigatorSpec.m
+++ b/MFBNavigationTests/MFBPushPopNavigatorSpec.m
@@ -2,7 +2,6 @@
 @import OCMock;
 @import Quick;
 
-#import "MFBNavigationChildrenReplacer.h"
 #import "MFBPushPopNavigator.h"
 #import "MFBPushPopNavigator+Test.h"
 #import "MFBSuspendibleUIQueue.h"

--- a/MFBNavigationTests/MFBPushPopNavigatorSpec.m
+++ b/MFBNavigationTests/MFBPushPopNavigatorSpec.m
@@ -716,4 +716,71 @@ describe(@"delegate forwarding", ^{
     });
 });
 
+describe(@"current unwind token", ^{
+    __block id queueMock;
+    __block id unwindTokenFactoryMock;
+    __block id unwindTokenMock;
+
+    beforeEach(^{
+        queueMock = OCMStrictClassMock(MFBSuspendibleUIQueue.class);
+
+        OCMStub([navigationControllerMock setDelegate:OCMOCK_ANY]);
+
+        pushPopNavigator = [[MFBPushPopNavigator alloc] initWithNavigationController:navigationControllerMock
+                                                                     transitionQueue:queueMock
+                                                                      modalNavigator:modalNavigatorMock];
+
+        unwindTokenFactoryMock = OCMStrictClassMock(MFBUIKitUnwindTokenFactory.class);
+        unwindTokenMock = OCMStrictClassMock(MFBUIKitUnwindToken.class);
+
+        [pushPopNavigator setUnwindTokenFactory:unwindTokenFactoryMock];
+    });
+
+    it(@"gets token from factory & sets its unwind target if navigation controller is not empty", ^{
+        id topViewControllerStub = [NSObject new];
+
+        OCMExpect([unwindTokenFactoryMock unwindTokenWithDelegate:(id) pushPopNavigator]).andReturn(unwindTokenMock);
+
+        id enqueuedBlockArgument = [OCMArg checkWithBlock:^(dispatch_block_t block) {
+            OCMExpect([navigationControllerMock topViewController]).andReturn(topViewControllerStub);
+            OCMExpect([unwindTokenMock setUnwindTarget:topViewControllerStub]);
+
+            block();
+
+            return YES;
+        }];
+
+        OCMExpect([queueMock enqueueBlock:enqueuedBlockArgument]);
+
+        __auto_type token = [pushPopNavigator currentUnwindToken];
+
+        XCTAssertEqual(token, unwindTokenMock);
+
+        OCMVerifyAll(queueMock);
+        OCMVerifyAll(navigationControllerMock);
+        OCMVerifyAll(unwindTokenMock);
+    });
+
+    it(@"gets token from factory & doesn't set unwind factory if there's none", ^{
+        OCMExpect([unwindTokenFactoryMock unwindTokenWithDelegate:(id) pushPopNavigator]).andReturn(unwindTokenMock);
+
+        id enqueuedBlockArgument = [OCMArg checkWithBlock:^(dispatch_block_t block) {
+            OCMExpect([navigationControllerMock topViewController]).andReturn(nil);
+
+            block();
+
+            return YES;
+        }];
+
+        OCMExpect([queueMock enqueueBlock:enqueuedBlockArgument]);
+
+        __auto_type token = [pushPopNavigator currentUnwindToken];
+
+        XCTAssertEqual(token, unwindTokenMock);
+
+        OCMVerifyAll(queueMock);
+        OCMVerifyAll(navigationControllerMock);
+    });
+});
+
 QuickSpecEnd

--- a/MFBNavigationTests/MFBUIKitUnwindToken.m
+++ b/MFBNavigationTests/MFBUIKitUnwindToken.m
@@ -29,6 +29,20 @@ context(@"has unwind target", ^{
 
         OCMVerifyAll(unwindDelegateMock);
     });
+
+    context(@"target deallocated", ^{
+        beforeEach(^{
+            unwindTarget = nil;
+        });
+
+        it(@"does nothing", ^{
+            [token unwind];
+        });
+    });
+
+    it(@"throws if target is set once more", ^{
+        XCTAssertThrows([token setUnwindTarget:unwindTarget]);
+    });
 });
 
 context(@"triggered", ^{
@@ -42,6 +56,23 @@ context(@"triggered", ^{
         [token setUnwindTarget:unwindTarget];
 
         OCMVerifyAll(unwindDelegateMock);
+    });
+
+    it(@"throws if unwind called once more", ^{
+        XCTAssertThrows([token unwind]);
+    });
+});
+
+context(@"unwound", ^{
+    beforeEach(^{
+        [unwindDelegateMock makeNice];
+        [token setUnwindTarget:unwindTarget];
+        [token unwind];
+        [unwindDelegateMock makeStrict];
+    });
+
+    it(@"throws when asked to unwind", ^{
+        XCTAssertThrows([token unwind]);
     });
 });
 

--- a/MFBNavigationTests/MFBUIKitUnwindToken.m
+++ b/MFBNavigationTests/MFBUIKitUnwindToken.m
@@ -1,0 +1,48 @@
+@import Nimble;
+@import OCMock;
+@import Quick;
+
+#import "MFBUIKitUnwindToken.h"
+
+QuickSpecBegin(UIKitUnwindToken)
+
+__block MFBUIKitUnwindToken *token;
+__block id unwindTarget;
+__block id unwindDelegateMock;
+
+beforeEach(^{
+    token = [MFBUIKitUnwindToken new];
+    unwindTarget = [NSObject new];
+    unwindDelegateMock = OCMStrictProtocolMock(@protocol(MFBUIKitUnwindDelegate));
+    token.delegate = unwindDelegateMock;
+});
+
+context(@"has unwind target", ^{
+    beforeEach(^{
+        [token setUnwindTarget:unwindTarget];
+    });
+
+    it(@"unwinds immediately when asked to", ^{
+        OCMExpect([unwindDelegateMock unwindToTarget:unwindTarget]);
+
+        [token unwind];
+
+        OCMVerifyAll(unwindDelegateMock);
+    });
+});
+
+context(@"triggered", ^{
+    beforeEach(^{
+        [token unwind];
+    });
+
+    it(@"unwinds upon setting unwind target", ^{
+        OCMExpect([unwindDelegateMock unwindToTarget:unwindTarget]);
+
+        [token setUnwindTarget:unwindTarget];
+
+        OCMVerifyAll(unwindDelegateMock);
+    });
+});
+
+QuickSpecEnd

--- a/MFBNavigationTests/MFBUIKitUnwindToken.m
+++ b/MFBNavigationTests/MFBUIKitUnwindToken.m
@@ -58,8 +58,8 @@ context(@"triggered", ^{
         OCMVerifyAll(unwindDelegateMock);
     });
 
-    it(@"throws if unwind called once more", ^{
-        XCTAssertThrows([token unwind]);
+    it(@"unwind is idempotent", ^{
+        [token unwind];
     });
 });
 
@@ -71,8 +71,8 @@ context(@"unwound", ^{
         [unwindDelegateMock makeStrict];
     });
 
-    it(@"throws when asked to unwind", ^{
-        XCTAssertThrows([token unwind]);
+    it(@"unwind is idempotent", ^{
+        [token unwind];
     });
 });
 

--- a/MFBNavigationTests/MFBUIKitUnwindTokenSpec.m
+++ b/MFBNavigationTests/MFBUIKitUnwindTokenSpec.m
@@ -57,10 +57,6 @@ context(@"triggered", ^{
 
         OCMVerifyAll(unwindDelegateMock);
     });
-
-    it(@"unwind is idempotent", ^{
-        [token unwind];
-    });
 });
 
 context(@"unwound", ^{


### PR DESCRIPTION
This PR introduces a way to make "bookmarks" in order to be able to unwind to a specific place in navigation hierarchy later.

So far only push/pop navigation is supported but public API is generic and should work for modal navigation as well.