### PR TITLE
Doesn't suspend queue if not animated

### DIFF
--- a/MFBNavigation/MFBPushPopNavigator.m
+++ b/MFBNavigation/MFBPushPopNavigator.m
@@ -263,7 +263,9 @@
             [_transitionQueue resume];
         }];
 
-    [_transitionQueue suspend];
+    if (animated) {
+        [_transitionQueue suspend];
+    }
 }
 
 - (void)navigationController:(UINavigationController *)navigationController

--- a/MFBNavigationTests/MFBPushPopNavigatorSpec.m
+++ b/MFBNavigationTests/MFBPushPopNavigatorSpec.m
@@ -716,6 +716,35 @@ describe(@"delegate forwarding", ^{
     });
 });
 
+describe(@"external navigation", ^{
+    __block id<UINavigationControllerDelegate> internalDelegate;
+    __block id viewControllerStub;
+    __block id transitionQueueMock;
+
+    beforeEach(^{
+        viewControllerStub = [NSObject new];
+        transitionQueueMock = OCMStrictClassMock([MFBSuspendibleUIQueue class]);
+
+        OCMStub([navigationControllerMock setDelegate:[OCMArg checkWithBlock:^(id obj) {
+            internalDelegate = obj;
+
+            return YES;
+        }]]);
+
+        pushPopNavigator = [[MFBPushPopNavigator alloc] initWithNavigationController:navigationControllerMock
+                                                                     transitionQueue:transitionQueueMock
+                                                                      modalNavigator:modalNavigatorMock];
+
+        OCMStub([navigationControllerMock transitionCoordinator]).andReturn(nil);
+    });
+
+    it(@"doesn't suspend queue on willShowViewController when not animated", ^{
+        [internalDelegate navigationController:navigationControllerMock
+                        willShowViewController:viewControllerStub
+                                      animated:NO];
+    });
+});
+
 describe(@"current unwind token", ^{
     __block id queueMock;
     __block id unwindTokenFactoryMock;


### PR DESCRIPTION
It seems that UIKit calls this method in cases you don't expect. For example `snapshotViewAfterScreenUpdates` under specific conditions triggers `navigationController:willShowViewController:animated:` without consequent call `navigationController:didShowViewController:animated:` that suspends the transition queue forever.